### PR TITLE
Add Description to u-boot package

### DIFF
--- a/scripts/compilation.sh
+++ b/scripts/compilation.sh
@@ -185,6 +185,7 @@ compile_uboot()
 	Provides: armbian-u-boot
 	Replaces: armbian-u-boot
 	Conflicts: armbian-u-boot, u-boot-sunxi
+	Description: Das U-Boot bootloader for ${BOARD}
 	EOF
 
 	# copy config file to the package


### PR DESCRIPTION
The uboot package does not contain a Description which will continuously add erros to apt + dpkg based package installations:

```
dpkg: warning: parsing file '/var/lib/dpkg/status' near line 7868 package 'linux-u-boot-h616-current':
 missing 'Description' field
```

We therefore add a Description field to the u-boot package