### PR TITLE
Use proper voltages in regulators

### DIFF
--- a/kernel/arch/arm64/boot/dts/allwinner/sun50i-h616-biqu.dtsi
+++ b/kernel/arch/arm64/boot/dts/allwinner/sun50i-h616-biqu.dtsi
@@ -311,8 +311,8 @@
 		regulators{
 			reg_dcdc1: dcdc1 {
 				regulator-name = "axp1530-dcdc1";
-				regulator-min-microvolt = <500000>;
-				regulator-max-microvolt = <3400000>;
+				regulator-min-microvolt = <810000>;
+				regulator-max-microvolt = <990000>;
 				regulator-step-delay-us = <25>;
 				regulator-final-delay-us = <50>;
 				regulator-always-on;
@@ -320,8 +320,8 @@
 
 			reg_dcdc2: dcdc2 {
 				regulator-name = "axp1530-dcdc2";
-				regulator-min-microvolt = <500000>;
-				regulator-max-microvolt = <1540000>;
+				regulator-min-microvolt = <810000>;
+				regulator-max-microvolt = <1100000>;
 				regulator-step-delay-us = <25>;
 				regulator-final-delay-us = <50>;
 				regulator-ramp-delay = <200>; // FIXME
@@ -330,8 +330,8 @@
 
 			reg_dcdc3: dcdc3 {
 				regulator-name = "axp1530-dcdc3";
-				regulator-min-microvolt = <500000>;
-				regulator-max-microvolt = <1220000>;
+				regulator-min-microvolt = <1350000>;
+				regulator-max-microvolt = <1350000>;
 				regulator-step-delay-us = <25>;
 				regulator-final-delay-us = <50>;
 				regulator-always-on;


### PR DESCRIPTION
Voltages provided in the DTS are incorrect and could harm the hardware.

Correct this mistake and use proper voltages.
GPU operating range is 0.81V to 0.99V
CPU operating range is 0.81V to 1.1V
The DRAM also received a changed in the form of fixed voltage. There is simply no need to have a range when we know DDR3L RAM needs 1.35V.