### PR TITLE
[CRITICAL] arm64: dts: h616: cb1: Fix DRAM voltage

### DIFF
--- a/kernel/arch/arm64/boot/dts/allwinner/sun50i-h616-biqu.dtsi
+++ b/kernel/arch/arm64/boot/dts/allwinner/sun50i-h616-biqu.dtsi
@@ -331,7 +331,7 @@
 			reg_dcdc3: dcdc3 {
 				regulator-name = "axp1530-dcdc3";
 				regulator-min-microvolt = <1350000>;
-				regulator-max-microvolt = <1350000>;
+				regulator-max-microvolt = <1500000>;
 				regulator-step-delay-us = <25>;
 				regulator-final-delay-us = <50>;
 				regulator-always-on;


### PR DESCRIPTION
SPL can set the voltage to 1.5V thus making kernel unable to boot as AXP20X driver will refuse to give 1.5V to the regulator. 

Correct this by extending the DRAM range to 1.5V for exactly this case.