### PR TITLE
arm64: dts: allwinner: h616: Correct voltage for GPU OPP table

### DIFF
--- a/kernel/arch/arm64/boot/dts/allwinner/sun50i-h616-biqu.dtsi
+++ b/kernel/arch/arm64/boot/dts/allwinner/sun50i-h616-biqu.dtsi
@@ -161,23 +161,23 @@
 
 		opp-200000000 {
 			opp-hz = /bits/ 64 <200000000>;
-			opp-microvolt = <1100000>;
+			opp-microvolt = <990000>;
 		};
 		opp-312000000 {
 			opp-hz = /bits/ 64 <312000000>;
-			opp-microvolt = <1100000>;
+			opp-microvolt = <990000>;
 		};
 		opp-432000000 {
 			opp-hz = /bits/ 64 <432000000>;
-			opp-microvolt = <1100000>;
+			opp-microvolt = <990000>;
 		};
 		opp-528000000 {
 			opp-hz = /bits/ 64 <528000000>;
-			opp-microvolt = <1100000>;
+			opp-microvolt = <990000>;
 		};
 		opp-650000000 {
 			opp-hz = /bits/ 64 <650000000>;
-			opp-microvolt = <1100000>;
+			opp-microvolt = <990000>;
 		};
 	};
 };


### PR DESCRIPTION
Max operating voltage for the GPU is 0.99V and that is what the regulator is also set to.

Do not overvolt the GPU.