### PR TITLE
Fixed ghost input tft screen by second rules

### DIFF
--- a/kernel/arch/arm64/boot/dts/allwinner/sun50i-h616-biqu.dtsi
+++ b/kernel/arch/arm64/boot/dts/allwinner/sun50i-h616-biqu.dtsi
@@ -128,6 +128,7 @@
 			reg = <0x48>;
 			status = "disabled";
 			ti,x-plate-ohms = <660>;
+			ti,y-plate-ohms = <660>;
 			ti,rt-thr = <3000>;
 			ti,fuzzx = <32>;
 			ti,fuzzy = <16>;

--- a/kernel/drivers/input/touchscreen/tsc2007.h
+++ b/kernel/drivers/input/touchscreen/tsc2007.h
@@ -65,6 +65,7 @@ struct tsc2007 {
 
 	u16			model;
 	u16			x_plate_ohms;
+	u16			y_plate_ohms;
 	u16			max_rt;
 	u16			rt_thr;
 	u8			touched;

--- a/kernel/drivers/input/touchscreen/tsc2007_core.c
+++ b/kernel/drivers/input/touchscreen/tsc2007_core.c
@@ -70,22 +70,25 @@ static void tsc2007_read_values(struct tsc2007 *tsc, struct ts_event *tc)
 
 u32 tsc2007_calculate_resistance(struct tsc2007 *tsc, struct ts_event *tc)
 {
-	u32 rt = 0;
+    u32 rt = 0;
+    if (tc->x == MAX_12BIT){
+        /* dev_info(&tsc->client->dev, "[DEBUG TSC] RESISTANCE CALCULATED | TC->X is MAX_12BIT Force to 0 || TC Z1: (%4d) | TC Z2: (%4d) | TC X: (%4d) | TC Y: (%4d)", tc->z1, tc->z2, tc->x, tc->y);*/
+        tc->x = 0;
+    }
 
-	/* range filtering */
-	if (tc->x == MAX_12BIT)
-		tc->x = 0;
+    if (tc->y == MAX_12BIT){
+        /*dev_info(&tsc->client->dev, "[DEBUG TSC] RESISTANCE CALCULATED | TC->Y is MAX_12BIT Force to 0 || TC Z1: (%4d) | TC Z2: (%4d) | TC X: (%4d) | TC Y: (%4d)", tc->z1, tc->z2, tc->x, tc->y);*/
+        tc->y = 0;
+    }
 
-	if (likely(tc->x && tc->z1)) {
-		/* compute touch resistance using equation #1 */
-		rt = tc->z2 - tc->z1;
-		rt *= tc->x;
-		rt *= tsc->x_plate_ohms;
-		rt /= tc->z1;
-		rt = (rt + 2047) >> 12;
-	}
 
-	return rt;
+    if (likely(tc->x && tc->y && tc->z1)) {
+        return (tsc->x_plate_ohms * tc->x / 4096) * ((4096 / tc->z1) - 1) - tsc->y_plate_ohms * (1 - tc->y / 4096);
+    }else{
+       /*dev_info(&tsc->client->dev, "[DEBUG TSC] RESISTANCE CALCULATED | Missing mandatory Data TCX(%4d) | TCY(%4d) | TCZ1(%4d)",tc->x,tc->y,tc->z1);*/
+       return false;
+    }
+
 }
 
 bool tsc2007_is_pen_down(struct tsc2007 *ts)
@@ -180,6 +183,7 @@ static irqreturn_t tsc2007_soft_poll(int irq, void *handle)
 	struct input_dev *input = ts->input;
 	struct ts_event tc;
 	u32 rt;
+	bool skipSync = false;
 
 	if(!ts->stopped) {
 
@@ -189,46 +193,38 @@ static irqreturn_t tsc2007_soft_poll(int irq, void *handle)
 
 		rt = tsc2007_calculate_resistance(ts, &tc);
 
-		if (rt == 0 || rt == 256) {
+        if (likely(rt)) {
 
-			/*
-				* Sample found inconsistent by debouncing or pressure is
-				* beyond the maximum. Don't report it to user space,
-				* repeat at least once more the measurement.
-				*/
-			dev_dbg(&ts->client->dev, "ignored pressure %d\n", rt);
+            /* range >= 0 && <= 4096 */
+            if (rt > 0 && rt <= ts->max_rt) {
+                    rt = ts->max_rt - rt;
+                    input_report_key(input, BTN_TOUCH, 1);
+                    input_report_abs(input, ABS_X, tc.y);
+                    input_report_abs(input, ABS_Y, 4096 - tc.x);
+                    input_report_abs(input, ABS_PRESSURE, rt);
+                    input_sync(input);
+                    /*dev_info(&ts->client->dev, "[DEBUG TSC] TOUCH TRIGGERED | RT: (%4d) | TC Z1: (%4d) | TC Z2: (%4d) | TC X: (%4d) | TC Y: (%4d)", rt, tc.z1, tc.z2, tc.x, tc.y);*/
 
-		} else {
+            } else {
+                //Discard Input Ghost or inconsistent
+                /*dev_info(&ts->client->dev, "[DEBUG TSC] TOUCH DISCARD | RT: (%4d) | TC Z1: (%4d) | TC Z2: (%4d) | TC X: (%4d) | TC Y: (%4d)", rt, tc.z1, tc.z2, tc.x, tc.y);*/
+                skipSync= true;
+            }
+        }else{
+       	    // No touch event or missing data for rt calculation
+            skipSync= true;
+        }
 
-			if (rt < ts->rt_thr) {
-
-				dev_dbg(&ts->client->dev,
-					"DOWN point(%4d,%4d), resistance (%4u)\n",
-					tc.x, tc.y, rt);
-
-				rt = ts->max_rt - rt;
-
-				input_report_key(input, BTN_TOUCH, 1);
-				input_report_abs(input, ABS_X, tc.y);
-				input_report_abs(input, ABS_Y, 4096 - tc.x);
-				input_report_abs(input, ABS_PRESSURE, rt);
-
-				input_sync(input);
-				ts->touched = 1;
-
-			} else if (ts->touched == 1) {
-
-				dev_dbg(&ts->client->dev, "UP\n");
-
-				input_report_key(input, BTN_TOUCH, 0);
-				input_report_abs(input, ABS_PRESSURE, 0);
-				input_sync(input);
-				ts->touched = 0;
-			}
-		}
-
-
+	}else{
+	    // TFT Not initialized
+	    /* dev_info(&ts->client->dev, "DEBUG TSC: TouchScreen Stopped"); */
 	}
+
+    if(skipSync){
+        input_report_key(input, BTN_TOUCH, 0);
+        input_report_abs(input, ABS_PRESSURE, 0);
+        input_sync(input);
+    }
 
 	return IRQ_HANDLED;
 }
@@ -339,6 +335,13 @@ static int tsc2007_probe_properties(struct device *dev, struct tsc2007 *ts)
 		ts->x_plate_ohms = val32;
 	} else {
 		dev_err(dev, "Missing ti,x-plate-ohms device property\n");
+		return -EINVAL;
+	}
+
+	if (!device_property_read_u32(dev, "ti,y-plate-ohms", &val32)) {
+		ts->y_plate_ohms = val32;
+	} else {
+		dev_err(dev, "Missing ti,y-plate-ohms device property\n");
 		return -EINVAL;
 	}
 

--- a/kernel/include/linux/platform_data/tsc2007.h
+++ b/kernel/include/linux/platform_data/tsc2007.h
@@ -7,6 +7,7 @@
 struct tsc2007_platform_data {
 	u16	model;				/* 2007. */
 	u16	x_plate_ohms;	/* must be non-zero value */
+	u16	y_plate_ohms;	/* must be non-zero value */
 	u16	max_rt; /* max. resistance above which samples are ignored */
 	unsigned long poll_period; /* time (in ms) between samples */
 	int	fuzzx; /* fuzz factor for X, Y and pressure axes */


### PR DESCRIPTION
I and others have experienced ghost input issues when changing the original flat cable with a longer one, causing interference with ghost inputs that lead to significant problems during printing.

The reference to the issue is here:
https://github.com/bigtreetech/TFT35-SPI/issues/15

I have updated the driver, now managing the RT calculation using the second formula, which involves the use of the Y plate, implemented similarly to the X plate.

After a week of testing and various fixes, the result is stable and functional. Occasionally, ghost inputs still occur, but addressing them would likely require hardware intervention or using the penirq, also documented in the touchscreen datasheet.